### PR TITLE
Undo a buggy change in ParseUtils

### DIFF
--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -267,24 +267,7 @@ ppFields fields x =
    vcat [ ppField name (getter x) | FieldDescr name getter _ <- fields ]
 
 ppField :: String -> Doc -> Doc
-ppField name fielddoc 
-   | isEmpty fielddoc         = empty
-   | name `elem` nestedFields = text name <> colon $+$ nest indentWith fielddoc
-   | otherwise                = text name <> colon <+> fielddoc
-   where
-      nestedFields =
-         [ "description"
-         , "build-depends"
-         , "data-files"
-         , "extra-source-files"
-         , "extra-tmp-files"
-         , "exposed-modules"
-         , "c-sources"
-         , "extra-libraries"
-         , "includes"
-         , "install-includes"
-         , "other-modules"
-         ]
+ppField name fielddoc = text name <> colon <+> fielddoc
 
 showFields :: [FieldDescr a] -> a -> String
 showFields fields = render . ($+$ text "") . ppFields fields


### PR DESCRIPTION
A change in commit https://github.com/haskell/cabal/commit/1ecd69c7127be446b42e736d72b5d6956a40db52 causes ppField to generate lines which contain only a four space indent, no "." and no other text.  This causes failures.  I've reported the issue in https://github.com/haskell/cabal/issues/1921.  This patch reverts the change, but it would be good if an improved version of this change could be submitted.
