### PR TITLE
Add hcVersion to get version of a particular compiler flavor

### DIFF
--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -22,7 +22,7 @@ module Distribution.Simple.Compiler (
         -- * Haskell implementations
         module Distribution.Compiler,
         Compiler(..),
-        showCompilerId, compilerFlavor, compilerVersion, hcVersion,
+        showCompilerId, compilerFlavor, compilerVersion, compilerFlavorVersion,
 
         -- * Support for package databases
         PackageDB(..),
@@ -76,9 +76,9 @@ compilerFlavor = (\(CompilerId f _ _) -> f) . compilerId
 compilerVersion :: Compiler -> Version
 compilerVersion = (\(CompilerId _ v _) -> v) . compilerId
 
-hcVersion :: CompilerFlavor -> Compiler -> Maybe Version
-hcVersion hc comp = hcVersion' (compilerId comp)
-    where hcVersion' (CompilerId hc' v next) = if hc' == hc then Just v else maybe Nothing hcVersion' next
+compilerFlavorVersion :: CompilerFlavor -> Compiler -> Maybe Version
+compilerFlavorVersion hc comp = compilerFlavorVersion' (compilerId comp)
+    where compilerFlavorVersion' (CompilerId hc' v next) = if hc' == hc then Just v else maybe Nothing compilerFlavorVersion' next
 
 -- ------------------------------------------------------------
 -- * Package databases

--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -22,7 +22,7 @@ module Distribution.Simple.Compiler (
         -- * Haskell implementations
         module Distribution.Compiler,
         Compiler(..),
-        showCompilerId, compilerFlavor, compilerVersion,
+        showCompilerId, compilerFlavor, compilerVersion, hcVersion,
 
         -- * Support for package databases
         PackageDB(..),
@@ -75,6 +75,10 @@ compilerFlavor = (\(CompilerId f _ _) -> f) . compilerId
 
 compilerVersion :: Compiler -> Version
 compilerVersion = (\(CompilerId _ v _) -> v) . compilerId
+
+hcVersion :: CompilerFlavor -> Compiler -> Maybe Version
+hcVersion hc comp = hcVersion' (compilerId comp)
+    where hcVersion' (CompilerId hc' v next) = if hc' == hc then Just v else maybe Nothing hcVersion' next
 
 -- ------------------------------------------------------------
 -- * Package databases

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -33,7 +33,7 @@ import Distribution.PackageDescription as PD
          , TestSuite(..), TestSuiteInterface(..)
          , Benchmark(..), BenchmarkInterface(..) )
 import Distribution.Simple.Compiler
-         ( CompilerFlavor(..), Compiler(..), hcVersion )
+         ( CompilerFlavor(..), Compiler(..), compilerFlavorVersion )
 import Distribution.Simple.GHC ( componentGhcOptions, ghcLibDir )
 import Distribution.Simple.Program.GHC
          ( GhcOptions(..), GhcDynLinkMode(..), renderGhcOptions )
@@ -149,7 +149,7 @@ haddock pkg_descr lbi suffixes flags = do
 
     haddockGhcVersionStr <- rawSystemProgramStdout verbosity confHaddock
                               ["--ghc-version"]
-    case (simpleParse haddockGhcVersionStr, hcVersion GHC comp) of
+    case (simpleParse haddockGhcVersionStr, compilerFlavorVersion GHC comp) of
       (Nothing, _) -> die "Could not get GHC version from Haddock"
       (_, Nothing) -> die "Could not get GHC version from compiler"
       (Just haddockGhcVersion, Just ghcVersion)
@@ -278,7 +278,7 @@ fromLibrary verbosity tmp lbi lib clbi htmlTemplate haddockVersion = do
             else if withSharedLib lbi
             then return sharedOpts
             else die "Must have vanilla or shared libraries enabled in order to run haddock"
-    ghcVersion <- maybe (die "Compiler has no GHC version") return (hcVersion GHC (compiler lbi))
+    ghcVersion <- maybe (die "Compiler has no GHC version") return (compilerFlavorVersion GHC (compiler lbi))
     return ifaceArgs {
       argHideModules = (mempty,otherModules $ bi),
       argGhcOptions  = toFlag (opts, ghcVersion),
@@ -317,7 +317,7 @@ fromExecutable verbosity tmp lbi exe clbi htmlTemplate haddockVersion = do
             else if withSharedLib lbi
             then return sharedOpts
             else die "Must have vanilla or shared libraries enabled in order to run haddock"
-    ghcVersion <- maybe (die "Compiler has no GHC version") return (hcVersion GHC (compiler lbi))
+    ghcVersion <- maybe (die "Compiler has no GHC version") return (compilerFlavorVersion GHC (compiler lbi))
     return ifaceArgs {
       argGhcOptions = toFlag (opts, ghcVersion),
       argOutputDir  = Dir (exeName exe),


### PR DESCRIPTION
This resolves the error message saying the compiler is version 0.1.0 but haddock needs version 7.8.3.  It adds the hcVersion function and modifies Haddock.hs to use hcVersion GHC instead of compilerVersion.  Luite, I think you said you were working on this stuff, so this may duplicate some change you are working on.
