### PR TITLE
Support the new network-uri package

### DIFF
--- a/cabal-install/Distribution/Client/BuildReports/Upload.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Upload.hs
@@ -51,10 +51,15 @@ postBuildReport uri buildReport = do
   }
   case rspCode response of
     (3,0,3) | [Just buildId] <- [ do rel <- parseRelativeReference location
+-- Caution MIN_VERSION_network_uri and MIN_VERSION_network won't both be defined
+#if defined(MIN_VERSION_network_uri)
+                                     return $ relativeTo rel uri
+#else
 #if MIN_VERSION_network(2,4,0)
                                      return $ relativeTo rel uri
 #else
                                      relativeTo rel uri
+#endif
 #endif
                                   | Header HdrLocation location <- rspHeaders response ]
               -> return $ buildId

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -41,7 +41,6 @@ Flag old-directory
 Flag network-uri
   description:  Get Network.URI from the network-uri package
   default:      True
-  manual:       True
 
 executable cabal
     main-is:        Main.hs

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -38,6 +38,11 @@ Flag old-directory
   description:  Use directory < 1.2 and old-time
   default:      False
 
+Flag network-uri
+  description:  Get Network.URI from the network-uri package
+  default:      True
+  manual:       True
+
 executable cabal
     main-is:        Main.hs
     ghc-options:    -Wall -fwarn-tabs
@@ -130,7 +135,6 @@ executable cabal
         filepath   >= 1.0      && < 1.4,
         HTTP       >= 4000.2.5 && < 4000.3,
         mtl        >= 2.0      && < 3,
-        network    >= 2.0      && < 2.6,
         pretty     >= 1        && < 1.2,
         random     >= 1        && < 1.1,
         stm        >= 2.0      && < 3,
@@ -143,6 +147,11 @@ executable cabal
     else
       build-depends: directory >= 1.2 && < 1.3,
                      process   >= 1.1.0.2  && < 1.3
+
+    if flag(network-uri)
+      build-depends: network-uri >= 2.6
+    else
+      build-depends: network >= 2.0 && < 2.6
 
     if os(windows)
       build-depends: Win32 >= 2 && < 3


### PR DESCRIPTION
There is an #ifdef on the network version which becomes an #ifdef on the version of the new network-uri package, but it just checks whether the network_uri macro is defined because (a) if we are building with an older version of network it won't be and (b) if it _is_ defined the version is sure to be new enough.
